### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/itcase/pyramid_elfinder.png?label=ready&title=Ready)](https://waffle.io/itcase/pyramid_elfinder)
 Forked from [elfinder-pyramid](http://github.com/aleksandr-rakov/elfinder-pyramid) writed by [Aleksandr Rakov](http://github.com/aleksandr-rakov)
 
 connector.py


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/itcase/pyramid_elfinder

This was requested by a real person (user uralbash) on waffle.io, we're not trying to spam you.
